### PR TITLE
Change calling drush alias generation script

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -42,7 +42,7 @@ hooks:
     # The deploy hook runs after your application has been deployed and started.
     deploy: |
         set -e
-        ./drush/platformsh_generate_drush_yml.php
+        php ./drush/platformsh_generate_drush_yml.php
         cd web
         drush -y cache-rebuild
         drush -y updatedb

--- a/drush/platformsh_generate_drush_yml.php
+++ b/drush/platformsh_generate_drush_yml.php
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 /**
  * @file


### PR DESCRIPTION
If called as shell script, the drush PHP file needs to be set executable. However, in the template repository the script isn't marked as executable.

This results in:
`/bin/dash: 2: ./drush/platformsh_generate_drush_yml.php: Permission denied`

Calling it this way avoids the need for the executable bit.