### PR TITLE
Consider removing `drush entup` from the default deployment workflow

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,7 +47,6 @@ hooks:
         drush -y cache-rebuild
         drush -y updatedb
         drush -y config-import
-        drush -y entup
 
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
Context:

- https://twitter.com/sanzante/status/1103654400604753920
- https://www.drupal.org/node/2554097 
- https://drupal.stackexchange.com/questions/221215/what-is-the-purpose-of-drush-entity-updates

It seems core/best practices advocate for using `entup` only for development purposes and it is not a recommended workflow in production environment.